### PR TITLE
general: T8595: add CLAUDE.md

### DIFF
--- a/.cursorrules
+++ b/.cursorrules
@@ -1,0 +1,1 @@
+CLAUDE.md

--- a/.cursorrules
+++ b/.cursorrules
@@ -1,1 +1,0 @@
-CLAUDE.md

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -1,0 +1,1 @@
+../CLAUDE.md

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,1 @@
+CLAUDE.md

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -45,7 +45,3 @@ Mirror twin: `VyOS-Networks/libtacplus-map`. Canonical side is here.
 
 - README dates to 2016 (`libtacplus_map v1.0.0`). Tracking patches against the original Cumulus / Dell drop is the maintenance posture, not active development.
 - Bump `libtacplus-map1` soname on any ABI change — both `libnss-tacplus` and `libpam-tacplus` build-depend on the dev package.
-
----
-
-This file is mirrored on Confluence: [`vyos/libtacplus-map`](https://internal.confluence.vyos.com/wiki/spaces/VYOS/pages/818479396). The Confluence page also carries the per-repo audit data (settings, workflows, secret counts, hygiene) that complements this CLAUDE.md. Edit either side; resync via the documentation pipeline.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,51 @@
+# CLAUDE.md
+
+## Project purpose
+
+Helper library for local mapping of TACACS+-authenticated users that have no `/etc/passwd` entry. Stores per-session mappings (uid/gid/home) so `libnss-tacplus` can answer `getpwnam` for users that came in via `libpam-tacplus`. Ships `libtacplus-map1` (runtime) and `libtacplus-map-dev` (headers); also includes `dumpmap` (debug tool) and a sudoers fragment.
+
+## Tech stack
+
+- C, GNU autotools (`configure.ac`, `Makefile.am`, `auto.sh`).
+- Debian packaging in `debian/` (debhelper >= 9, `dh-autoreconf`, `autoconf-archive`, `libaudit-dev`).
+- License: GPL-2.0 (per `COPYING`).
+
+## Build / test / run
+
+```sh
+./auto.sh
+make
+dpkg-buildpackage -us -uc
+```
+
+No bundled tests; verified end-to-end via `libnss-tacplus` + `libpam-tacplus` on a VyOS image.
+
+## Repository layout
+
+- `map_tacplus_user.c`, `map_tacplus_user.h` — mapping API.
+- `dumpmap.c` — diagnostic tool that dumps the active mapping.
+- `tacplus.sudo` — sudoers integration snippet.
+- `debian/` — packaging.
+
+## Cross-repo context
+
+Sits between `libpam-tacplus` (which authenticates the user and creates the mapping) and `libnss-tacplus` (which reads the mapping for NSS lookups). Built via `VyOS-Networks/vyos-build-packages`; consumed by `vyos/vyos-build`. Sibling auth packages: `libnss-mapuser`, `libpam-radius-auth`.
+
+## Conventions
+
+- Default branch `master`.
+- Commit / PR title format: `component: T12345: description` (Phorge task ID at https://vyos.dev).
+- Keep API stable — `libnss-tacplus` and `libpam-tacplus` link against this and are version-coupled.
+
+## Mirror relationship
+
+Mirror twin: `VyOS-Networks/libtacplus-map`. Canonical side is here.
+
+## Notes for future contributors
+
+- README dates to 2016 (`libtacplus_map v1.0.0`). Tracking patches against the original Cumulus / Dell drop is the maintenance posture, not active development.
+- Bump `libtacplus-map1` soname on any ABI change — both `libnss-tacplus` and `libpam-tacplus` build-depend on the dev package.
+
+---
+
+This file is mirrored on Confluence: [`vyos/libtacplus-map`](https://internal.confluence.vyos.com/wiki/spaces/VYOS/pages/818479396). The Confluence page also carries the per-repo audit data (settings, workflows, secret counts, hygiene) that complements this CLAUDE.md. Edit either side; resync via the documentation pipeline.


### PR DESCRIPTION
## Summary

Adds a single source of truth for repo-level agent instructions, plus three symlinks so different agentic tools all read the same content from one canonical file.

**Files added:**

| Path | Type | Consumed by |
|---|---|---|
| `CLAUDE.md` | real file | Claude Code, Anthropic agents |
| `AGENTS.md` | symlink → `CLAUDE.md` | tools that follow the AGENTS.md convention (e.g. OpenAI Codex) |
| `.cursorrules` | symlink → `CLAUDE.md` | Cursor |
| `.github/copilot-instructions.md` | symlink → `../CLAUDE.md` | GitHub Copilot ([docs](https://docs.github.com/en/copilot/how-tos/configure-custom-instructions-in-your-ide/add-repository-instructions-in-your-ide)) |

**Rationale**

- One source of truth — guidance lives in `CLAUDE.md`, the symlinks are zero-content. No drift between four files.
- Each agentic tool reads its canonical filename and gets the same content.
- Mac/Linux dev environments handle symlinks natively. Windows checkouts may render them as text files containing the target path; the canonical `CLAUDE.md` is unaffected and still rendered/served correctly by GitHub.

**Out of scope**

Path-specific Copilot instructions (`.github/instructions/*.instructions.md`) need YAML frontmatter (`applyTo:`) and target specific globs, so they cannot be symlinks. Not added here; they can be authored as separate small files per-repo if/when narrow path-scoped guidance is needed.

Tracked under [T8595](https://vyos.dev/T8595).

## Test plan

- [ ] `CLAUDE.md` renders on GitHub.
- [ ] `AGENTS.md`, `.cursorrules`, `.github/copilot-instructions.md` resolve to CLAUDE.md content (`readlink` returns the right target).
- [ ] CI passes.

🤖 Generated by [robots](https://vyos.io)
